### PR TITLE
[PMON] [Mellanox] fix syseepromd issue on simx

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -7,6 +7,7 @@
 try:
     from sonic_platform_base.platform_base import PlatformBase
     from sonic_platform.chassis import Chassis
+    from sonic_py_common.device_info import get_platform
     from . import utils
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -15,11 +16,14 @@ class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
         self._chassis = Chassis()
-        self._chassis.initialize_psu()
         self._chassis.initialize_eeprom()
-        if utils.is_host():
-            self._chassis.initialize_components()
-            self._chassis.initizalize_system_led()
-        else:
-            self._chassis.initialize_fan()
-            self._chassis.initialize_thermals()
+        platform_name = get_platform()
+        simx_platform = bool(platform_name and "simx" in platform_name)
+        if not simx_platform:
+            self._chassis.initialize_psu()
+            if utils.is_host():
+                self._chassis.initialize_components()
+                self._chassis.initizalize_system_led()
+            else:
+                self._chassis.initialize_fan()
+                self._chassis.initialize_thermals()


### PR DESCRIPTION
[PMON] syseepromd simx fix - avoid initializing sfp/thermal/components/fan/psu/leds on simx and create vpd_info file on hw_management when we use simx

#### Why I did it
this is a fix for issue in mellanox simx platforms. the syseepromd failed on the pmon docker. also "decode-syseeprom" failed also


#### How I did it
- before initializing thermal/components/fan/psu/leds --> check if we are running on simx
- creating the vpd_info on the hw_management folder.

#### How to verify it
- check if syseepromd process was loaded properly on the pmon docker.
- decode-syseeprom is working well without errors/warnings

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
fix issues on syseeprom on mellanox simulator platforms. problem was discovered on 202012 release.
