### PR TITLE
[WARM-REBOOT] fix issue of watch-dog on simx when executing warm-reboot

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -275,6 +275,9 @@ def get_watchdog():
         if device.startswith("watchdog") and is_mlnx_wd_main(device):
             watchdog_main_device_name = device
 
+    if watchdog_main_device_name is None:
+        return None
+
     watchdog_device_path = "/dev/{}".format(watchdog_main_device_name)
 
     watchdog = None


### PR DESCRIPTION
[WARM-REBOOT] fix issue of watch-dog on mellanox simulator platform when executing warm-reboot

#### Why I did it
to prevent python exception error when executing warm-reboot command on mellanox simulator platform
#### How I did it
return None on the watchdog python script on cases that watchdog file is not exist
#### How to verify it
warm-reboot is running well without the python error. error message will appear on log on these cases.
in order to avoid this error message we can simulate the watchdog on simx
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
[WARM-REBOOT] fix issue of watch-dog on mellanox simulator platform when executing warm-reboot

