### PR TITLE
LLDPD fix to port remove and immediately create problem

### DIFF
--- a/src/lldpd/patch/0012-fix-recreate-socket-on-ifindex-change.patch
+++ b/src/lldpd/patch/0012-fix-recreate-socket-on-ifindex-change.patch
@@ -1,0 +1,82 @@
+diff --git a/src/daemon/interfaces-linux.c b/src/daemon/interfaces-linux.c
+index a8280c8..a51440a 100644
+--- a/src/daemon/interfaces-linux.c
++++ b/src/daemon/interfaces-linux.c
+@@ -775,7 +775,7 @@ iflinux_handle_bond(struct lldpd *cfg, struct interfaces_device_list *interfaces
+ 			created = 1;
+ 		}
+ 		if (hardware->h_flags) continue;
+-		if (hardware->h_ops != &bond_ops) {
++		if (hardware->h_ops != &bond_ops || hardware->h_ifindex_changed) {
+ 			if (!created) {
+ 				log_debug("interfaces",
+ 				    "bond %s is converted from another type of interface",
+@@ -794,7 +794,7 @@ iflinux_handle_bond(struct lldpd *cfg, struct interfaces_device_list *interfaces
+ 		} else bmaster = hardware->h_data;
+ 		bmaster->index = master->index;
+ 		strlcpy(bmaster->name, master->name, IFNAMSIZ);
+-		if (hardware->h_ops != &bond_ops) {
++		if (hardware->h_ops != &bond_ops || hardware->h_ifindex_changed) {
+ 			if (iface_bond_init(cfg, hardware) != 0) {
+ 				log_warn("interfaces", "unable to initialize %s",
+ 				    hardware->h_ifname);
+diff --git a/src/daemon/interfaces.c b/src/daemon/interfaces.c
+index 3c6c255..58db018 100644
+--- a/src/daemon/interfaces.c
++++ b/src/daemon/interfaces.c
+@@ -623,7 +623,7 @@ interfaces_helper_physical(struct lldpd *cfg,
+ 		}
+ 		if (hardware->h_flags)
+ 			continue;
+-		if (hardware->h_ops != ops) {
++		if (hardware->h_ops != ops || hardware->h_ifindex_changed) {
+ 			if (!created) {
+ 				log_debug("interfaces",
+ 				    "interface %s is converted from another type of interface",
+diff --git a/src/daemon/lldpd.c b/src/daemon/lldpd.c
+index 1d92dd3..f3e82e5 100644
+--- a/src/daemon/lldpd.c
++++ b/src/daemon/lldpd.c
+@@ -147,6 +147,12 @@ lldpd_get_hardware(struct lldpd *cfg, char *name, int index)
+ 	TAILQ_FOREACH(hardware, &cfg->g_hardware, h_entries) {
+ 		if (strcmp(hardware->h_ifname, name) == 0) {
+ 			if (hardware->h_flags == 0) {
++				if (hardware->h_ifindex != 0 &&
++				    hardware->h_ifindex != index) {
++					log_debug("interfaces", "%s changed index: from %d to %d",
++					    hardware->h_ifname, hardware->h_ifindex, index);
++					hardware->h_ifindex_changed = 1;
++				}
+ 				hardware->h_ifindex = index;
+ 				break;
+ 			}
+@@ -392,7 +398,8 @@ lldpd_reset_timer(struct lldpd *cfg)
+ 		}
+ 
+ 		/* Compare with the previous value */
+-		if (hardware->h_lport_previous &&
++		if (!hardware->h_ifindex_changed &&
++		    hardware->h_lport_previous &&
+ 		    output_len == hardware->h_lport_previous_len &&
+ 		    !memcmp(output, hardware->h_lport_previous, output_len)) {
+ 			log_debug("localchassis",
+@@ -402,6 +409,7 @@ lldpd_reset_timer(struct lldpd *cfg)
+ 			log_debug("localchassis",
+ 			    "change detected for port %s, resetting its timer",
+ 			    hardware->h_ifname);
++			hardware->h_ifindex_changed = 0;
+ 			levent_schedule_pdu(hardware);
+ 		}
+ 
+diff --git a/src/lldpd-structs.h b/src/lldpd-structs.h
+index f6b03d7..213f306 100644
+--- a/src/lldpd-structs.h
++++ b/src/lldpd-structs.h
+@@ -454,6 +454,7 @@ struct lldpd_hardware {
+ 					     removed if this is left
+ 					     to 0. */
+ 	int			 h_ifindex; /* Interface index, used by SNMP */
++	int			 h_ifindex_changed;  /* Interface index has changed */
+ 	char			 h_ifname[IFNAMSIZ]; /* Should be unique */
+ 	u_int8_t		 h_lladdr[ETHER_ADDR_LEN];
+ 

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -5,3 +5,4 @@
 0007-lib-fix-memory-leak-when-handling-I-O.patch
 0010-Ported-fix-for-length-exceeded-from-lldp-community.patch
 0011-fix-med-location-len.patch
+0012-fix-recreate-socket-on-ifindex-change.patch


### PR DESCRIPTION
Signed-off-by: tomeri <tomeri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
when we remove a port and add it back immediately - lldp is keep failing
warning message keeps appearing:
...
[WARN/lldp] unable to send packet on real device for Ethernet4: No such device or address
...


#### How I did it
on delete link events it will immediately execute delete without using aggregate events mechanism.

#### How to verify it
manual tests and run mellanox lldp regression tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
[LLDPD] fix to port remove and immediately create problem - on delete link events it will immediately execute delete without using aggregate events mechanism.

this patch was added to LLDPD on this PR:
https://github.com/lldpd/lldpd/pull/492

#### A picture of a cute animal (not mandatory but encouraged)

